### PR TITLE
Changes temporary log file's name and path

### DIFF
--- a/AutoMap_v1.2.sh
+++ b/AutoMap_v1.2.sh
@@ -266,7 +266,7 @@ if [ "$multivcf" == "Yes" ]; then
         multivcf3
     fi
 
-    nb="$(bcftools query -l $vcf 2> $here.log | wc -l | cut -d" " -f1 )"
+    nb="$(bcftools query -l $vcf 2> $here/.log | wc -l | cut -d" " -f1 )"
 
     for (( k=0; k<$nb; k++ ))
     do
@@ -306,10 +306,10 @@ if [ "$multivcf" == "No" ]; then
 
         nbvar=$(grep -v "#" $vcf | grep -P "AD|DP4|AO" | grep GT | wc -l)
 
-        nb="$(bcftools query -l $vcf 2> $here.log | wc -l | cut -d" " -f1 )"
+        nb="$(bcftools query -l $vcf 2> $here/.log | wc -l | cut -d" " -f1 )"
         if [ "$nb" == "1" ]; then
             if [ -z "${id}" ]; then
-                id="$(bcftools query -l $vcf 2> $here.log)"
+                id="$(bcftools query -l $vcf 2> $here/.log)"
                 if [ "$k" == "0" ]; then
                     allid=$id
                 fi
@@ -366,7 +366,7 @@ if [ "$multivcf" == "No" ]; then
         if [ -s $out/$id/$id.clean.tsv ]; then
             :
         else 
-            perl $here/Scripts/parse_vcf_v1.1.pl $out/$id/$id.tsv $out/$id/$id.clean.tsv 2> $here.log
+            perl $here/Scripts/parse_vcf_v1.1.pl $out/$id/$id.tsv $out/$id/$id.clean.tsv 2> $here/.log
             rm $out/$id/$id.tsv
         fi
 
@@ -389,7 +389,7 @@ if [ "$multivcf" == "No" ]; then
         input=$out/$id/$id.clean.qual.sort.tsv
         output_path=$out/$id
         output=$output_path/$id.HomRegions
-        perl $here/Scripts/homo_regions.pl $input $output $panel $panelname $window $windowthres $here/Scripts/trimming.sh $maxgap $here/Scripts/extend.sh $extend 2> $here.log
+        perl $here/Scripts/homo_regions.pl $input $output $panel $panelname $window $windowthres $here/Scripts/trimming.sh $maxgap $here/Scripts/extend.sh $extend 2> $here/.log
 
         echo 
         echo "3) Filtering of regions found and output to text file"
@@ -455,12 +455,12 @@ if [ "$multivcf" == "No" ]; then
         outputR=$output
         if [ "$chrx" == "Yes" ]; then
             
-            Rscript $here/Scripts/make_graph_chrX.R $id $output.tsv $outputR.pdf $size 2> $here.log
+            Rscript $here/Scripts/make_graph_chrX.R $id $output.tsv $outputR.pdf $size 2> $here/.log
         else
-            Rscript $here/Scripts/make_graph.R $id $output.tsv $outputR.pdf $size 2> $here.log
+            Rscript $here/Scripts/make_graph.R $id $output.tsv $outputR.pdf $size 2> $here/.log
         fi
 
-        rm -f $out/$id/$id.clean* $out/$id/$id.HomRegions.homozygosity* $here.log $vcf.chr
+        rm -f $out/$id/$id.clean* $out/$id/$id.HomRegions.homozygosity* $here/.log $vcf.chr
     done
 
     # Regions common to all
@@ -487,4 +487,4 @@ if [ "$multivcf" == "No" ]; then
     fi
 fi
 
-rm -f $here.log
+rm -f $here/.log


### PR DESCRIPTION
Automap creates a temporarily log file during runtime, and this file gets stored in the parent folder of the repo instead of within the repo. That is, it currently works like this:

```
tools/
├── AutoMap
│   ├── AutoMap_v1.2.sh
│   └── README.md
└── AutoMap.log          <--- log file in parent directory of the repo directory
```

instead of this:

```
tools/
└── AutoMap
    ├── .log             <--- log file within the repo directory
    ├── AutoMap_v1.2.sh
    └── README.md
```

This setup especially creates a problem when Automap is run in the docker/singularity container where one is not expected to provide read/write access to the parent directory of the repo.  This pull request modifies the current behavior to store the log file as `.log` inside the repo directory.